### PR TITLE
Add ghibli image redraw service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,12 @@
             <artifactId>kotlin-stdlib</artifactId>
             <version>2.1.20</version>
         </dependency>
+        <!-- Client for working with OpenAI via koog-agents -->
+        <dependency>
+            <groupId>ai.koog</groupId>
+            <artifactId>koog-agents</artifactId>
+            <version>1.0.0</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/src/main/kotlin/org/mshassium/codex_test_environment/ImageRedrawService.kt
+++ b/src/main/kotlin/org/mshassium/codex_test_environment/ImageRedrawService.kt
@@ -1,0 +1,29 @@
+package org.mshassium.codex_test_environment
+
+import ai.koog.agents.openai.OpenAIClient
+import ai.koog.agents.openai.image.EditImageRequest
+import ai.koog.agents.openai.image.EditImageResponse
+
+/**
+ * Service that sends an input image to OpenAI with a prompt to redraw it
+ * in Ghibli style and returns the resulting image as a base64 string.
+ */
+class ImageRedrawService(token: String) {
+
+    private val client = OpenAIClient(token)
+
+    /**
+     * Redraw the given base64 encoded image using OpenAI with Ghibli style.
+     *
+     * @param imageBase64 base64 encoded image
+     * @return base64 encoded result image
+     */
+    fun redrawGhibli(imageBase64: String): String {
+        val request = EditImageRequest(
+            image = imageBase64,
+            prompt = "перерисуй в стиле ghibli"
+        )
+        val response: EditImageResponse = client.createImageEdit(request)
+        return response.image
+    }
+}

--- a/src/main/kotlin/org/mshassium/codex_test_environment/Main.kt
+++ b/src/main/kotlin/org/mshassium/codex_test_environment/Main.kt
@@ -1,16 +1,21 @@
 package org.mshassium.codex_test_environment
 
-//TIP To <b>Run</b> code, press <shortcut actionId="Run"/> or
-// click the <icon src="AllIcons.Actions.Execute"/> icon in the gutter.
-fun main() {
-    val name = "Kotlin"
-    //TIP Press <shortcut actionId="ShowIntentionActions"/> with your caret at the highlighted text
-    // to see how IntelliJ IDEA suggests fixing it.
-    println("Hello, " + name + "!")
+/**
+ * Example entry point demonstrating the image redrawing service.
+ * Set environment variable `OPENAI_TOKEN` with your OpenAI API token
+ * and provide a base64 encoded image string as the first command line argument.
+ */
+fun main(args: Array<String>) {
+    val token = System.getenv("OPENAI_TOKEN")
+        ?: error("OPENAI_TOKEN environment variable is not set")
 
-    for (i in 1..5) {
-        //TIP Press <shortcut actionId="Debug"/> to start debugging your code. We have set one <icon src="AllIcons.Debugger.Db_set_breakpoint"/> breakpoint
-        // for you, but you can always add more by pressing <shortcut actionId="ToggleLineBreakpoint"/>.
-        println("i = $i")
+    if (args.isEmpty()) {
+        println("Please provide a base64 encoded image as the first argument")
+        return
     }
+
+    val inputImage = args[0]
+    val service = ImageRedrawService(token)
+    val result = service.redrawGhibli(inputImage)
+    println(result)
 }


### PR DESCRIPTION
## Summary
- add `ai.koog:koog-agents` dependency
- implement `ImageRedrawService` using Koog OpenAI client
- update `Main.kt` to use the new service

## Testing
- `mvn -q test` *(fails: `mvn` not found)*